### PR TITLE
Add abs configuration to fix chart version suffix

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -1,0 +1,4 @@
+replace-chart-version-with-git: true
+generate-metadata: true
+chart-dir: ./helm/aws-crossplane-cluster-config-operator
+destination: ./build


### PR DESCRIPTION
This ensures the chart gets pushed as `vX.Y.Z-<commit>` instead of the hardcoded `vX.Y.Z` version in `Chart.yaml`. Important for testing on development branches.