### PR TITLE
Add CAPA-created VPC and security group IDs for usage with the Cilium ENI mode feature (to add pod network security groups via Crossplane)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add CAPA-created VPC and security group IDs for usage with the Cilium ENI mode feature (to add pod network security groups via Crossplane)
+
 ## [0.1.1] - 2024-03-26
 
 ### Fixed

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -142,7 +142,7 @@ func newCluster(name string, annotationsKeyValues ...string) *capa.AWSCluster {
 			Region: "the-region",
 			NetworkSpec: capa.NetworkSpec{
 				VPC: capa.VPCSpec{
-					ID:        uuid.NewString(),
+					ID:        "vpc-1",
 					CidrBlock: fmt.Sprintf("10.%d.0.0/24", rand.Intn(255)),
 				},
 				Subnets: capa.Subnets{


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2563

To create a `SecurityGroup` object (+ ingress/egress rules) via Crossplane to allow pod networking for the Cilium ENI mode feature (pods run in their own, secondary AWS VPC CIDR), we need to refer to the VPC and `<WC>-controlplane` SG of the workload cluster. Hence, those IDs are provided here for usage in Crossplane resources.

The values hierarchy will change again (suggested: `global.crossplaneValues.aws.*`), but that's out of scope for this PR.