### PR TITLE
Configure the `ProviderConfig` to use the CAPA controller role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure the Crossplane `ProviderConfig` to use the CAPA controller role directly without going through a middle-man. For this to work, the CAPA controller role needs to have the correct trust policy granting access to the Crossplane providers ServiceAccount.
+
 ## [0.2.1] - 2024-08-14
 
 ### Fixed

--- a/controllers/capa_config_map_test.go
+++ b/controllers/capa_config_map_test.go
@@ -75,12 +75,9 @@ var _ = Describe("ConfigMapReconcilerCAPA", func() {
 			"credentials": MatchKeys(IgnoreExtras, Keys{
 				"source": Equal("WebIdentity"),
 				"webIdentity": MatchKeys(IgnoreExtras, Keys{
-					"roleARN": Equal(fmt.Sprintf("arn:aws:iam::%s:role/the-assume-role", accountID)),
+					"roleARN": Equal(fmt.Sprintf("arn:aws:iam::%s:role/the-provider-role", accountID)),
 				}),
 			}),
-			"assumeRoleChain": ConsistOf(MatchKeys(IgnoreExtras, Keys{
-				"roleARN": Equal(fmt.Sprintf("arn:aws:iam::%s:role/the-provider-role", accountID)),
-			})),
 		})))
 	}
 
@@ -167,11 +164,6 @@ var _ = Describe("ConfigMapReconcilerCAPA", func() {
 					"credentials": map[string]interface{}{
 						"source": "WebIdentity",
 						"webIdentity": map[string]interface{}{
-							"roleARN": fmt.Sprintf("arn:aws:iam::%s:role/some-other-assume-role", someOtherAccount),
-						},
-					},
-					"assumeRoleChain": []map[string]interface{}{
-						{
 							"roleARN": fmt.Sprintf("arn:aws:iam::%s:role/some-other-provider-role", someOtherAccount),
 						},
 					},
@@ -304,12 +296,9 @@ var _ = Describe("ConfigMapReconcilerCAPA", func() {
 				"credentials": MatchKeys(IgnoreExtras, Keys{
 					"source": Equal("WebIdentity"),
 					"webIdentity": MatchKeys(IgnoreExtras, Keys{
-						"roleARN": Equal(fmt.Sprintf("arn:aws-cn:iam::%s:role/the-assume-role", accountID)),
+						"roleARN": Equal(fmt.Sprintf("arn:aws-cn:iam::%s:role/the-provider-role", accountID)),
 					}),
 				}),
-				"assumeRoleChain": ConsistOf(MatchKeys(IgnoreExtras, Keys{
-					"roleARN": Equal(fmt.Sprintf("arn:aws-cn:iam::%s:role/the-provider-role", accountID)),
-				})),
 			})))
 		})
 	})

--- a/controllers/capa_config_map_test.go
+++ b/controllers/capa_config_map_test.go
@@ -91,7 +91,6 @@ var _ = Describe("ConfigMapReconcilerCAPA", func() {
 		reconciler = &controllers.ConfigMapReconciler{
 			Client:       k8sClient,
 			BaseDomain:   "base.domain.io",
-			AssumeRole:   "the-assume-role",
 			ProviderRole: "the-provider-role",
 		}
 		roleARN, err := arn.Parse(identity.Spec.RoleArn)

--- a/controllers/config_map.go
+++ b/controllers/config_map.go
@@ -47,7 +47,6 @@ type ConfigMapReconciler struct {
 	Client       client.Client
 	BaseDomain   string
 	ProviderRole string
-	AssumeRole   string
 }
 
 type ClusterInfo struct {
@@ -474,11 +473,6 @@ func (r *ConfigMapReconciler) getProviderConfigSpec(accountID, region string) ma
 		"credentials": map[string]interface{}{
 			"source": "WebIdentity",
 			"webIdentity": map[string]interface{}{
-				"roleARN": fmt.Sprintf("arn:%s:iam::%s:role/%s", partition, accountID, r.AssumeRole),
-			},
-		},
-		"assumeRoleChain": []map[string]interface{}{
-			{
 				"roleARN": fmt.Sprintf("arn:%s:iam::%s:role/%s", partition, accountID, r.ProviderRole),
 			},
 		},

--- a/controllers/eks_config_map_test.go
+++ b/controllers/eks_config_map_test.go
@@ -92,7 +92,6 @@ var _ = Describe("ConfigMapReconcilerEKS", func() {
 		reconciler = &controllers.ConfigMapReconciler{
 			Client:       k8sClient,
 			BaseDomain:   "base.domain.io",
-			AssumeRole:   "the-assume-role",
 			ProviderRole: "the-provider-role",
 		}
 		roleARN, err := arn.Parse(identity.Spec.RoleArn)

--- a/controllers/eks_config_map_test.go
+++ b/controllers/eks_config_map_test.go
@@ -76,12 +76,9 @@ var _ = Describe("ConfigMapReconcilerEKS", func() {
 			"credentials": MatchKeys(IgnoreExtras, Keys{
 				"source": Equal("WebIdentity"),
 				"webIdentity": MatchKeys(IgnoreExtras, Keys{
-					"roleARN": Equal(fmt.Sprintf("arn:aws:iam::%s:role/the-assume-role", accountID)),
+					"roleARN": Equal(fmt.Sprintf("arn:aws:iam::%s:role/the-provider-role", accountID)),
 				}),
 			}),
-			"assumeRoleChain": ConsistOf(MatchKeys(IgnoreExtras, Keys{
-				"roleARN": Equal(fmt.Sprintf("arn:aws:iam::%s:role/the-provider-role", accountID)),
-			})),
 		})))
 	}
 
@@ -168,11 +165,6 @@ var _ = Describe("ConfigMapReconcilerEKS", func() {
 					"credentials": map[string]interface{}{
 						"source": "WebIdentity",
 						"webIdentity": map[string]interface{}{
-							"roleARN": fmt.Sprintf("arn:aws:iam::%s:role/some-other-assume-role", someOtherAccount),
-						},
-					},
-					"assumeRoleChain": []map[string]interface{}{
-						{
 							"roleARN": fmt.Sprintf("arn:aws:iam::%s:role/some-other-provider-role", someOtherAccount),
 						},
 					},
@@ -288,12 +280,9 @@ var _ = Describe("ConfigMapReconcilerEKS", func() {
 				"credentials": MatchKeys(IgnoreExtras, Keys{
 					"source": Equal("WebIdentity"),
 					"webIdentity": MatchKeys(IgnoreExtras, Keys{
-						"roleARN": Equal(fmt.Sprintf("arn:aws-cn:iam::%s:role/the-assume-role", accountID)),
+						"roleARN": Equal(fmt.Sprintf("arn:aws-cn:iam::%s:role/the-provider-role", accountID)),
 					}),
 				}),
-				"assumeRoleChain": ConsistOf(MatchKeys(IgnoreExtras, Keys{
-					"roleARN": Equal(fmt.Sprintf("arn:aws-cn:iam::%s:role/the-provider-role", accountID)),
-				})),
 			})))
 		})
 	})

--- a/helm/aws-crossplane-cluster-config-operator/templates/deployment.yaml
+++ b/helm/aws-crossplane-cluster-config-operator/templates/deployment.yaml
@@ -35,7 +35,6 @@ spec:
           args:
             - --leader-elect
             - --provider-role={{ .Values.providerRole }}
-            - --assume-role={{ .Values.assumeRole }}
             - --base-domain={{ .Values.baseDomain }}
           securityContext:
             {{- with .Values.securityContext }}

--- a/helm/aws-crossplane-cluster-config-operator/values.schema.json
+++ b/helm/aws-crossplane-cluster-config-operator/values.schema.json
@@ -2,14 +2,10 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "required": [
-        "assumeRole",
         "baseDomain",
         "providerRole"
     ],
     "properties": {
-        "assumeRole": {
-            "type": "string"
-        },
         "baseDomain": {
             "type": "string"
         },

--- a/helm/aws-crossplane-cluster-config-operator/values.yaml
+++ b/helm/aws-crossplane-cluster-config-operator/values.yaml
@@ -10,7 +10,6 @@ pod:
   group:
     id: "1000"
 
-assumeRole: ""
 providerRole: ""
 baseDomain: ""
 

--- a/main.go
+++ b/main.go
@@ -58,11 +58,9 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
-	var assumeRoleARN string
 	var providerRoleARN string
 	var baseDomain string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&assumeRoleARN, "assume-role", "", "The role used by the aws crossplane provider.")
 	flag.StringVar(&providerRoleARN, "provider-role", "", "The role used by the aws crossplane provider.")
 	flag.StringVar(&baseDomain, "base-domain", "", "Management cluster base domain.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -94,7 +92,6 @@ func main() {
 	if err = (&controllers.ConfigMapReconciler{
 		Client:       mgr.GetClient(),
 		BaseDomain:   baseDomain,
-		AssumeRole:   assumeRoleARN,
 		ProviderRole: providerRoleARN,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Frigate")


### PR DESCRIPTION
Crossplane will use the CAPA controller role directly without going through a middle-man. For this to work, the CAPA controller role needs to have the correct trust policy granting access to the Crossplane providers ServiceAccount.

Requires https://github.com/giantswarm/giantswarm-aws-account-prerequisites/pull/122