### PR TITLE
Write out a value `oidcDomains` to the config map containing all service account issuer domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Configure the Crossplane `ProviderConfig` to use the CAPA controller role directly without going through a middle-man. For this to work, the CAPA controller role needs to have the correct trust policy granting access to the Crossplane providers ServiceAccount.
+- Write out a value `oidcDomains` to the config map containing all service account issuer domains, as defined by the new `aws.giantswarm.io/irsa-trust-domains` annotation on the AWSCluster. The primary domain is still written to value `oidcDomain`.
 
 ## [0.2.1] - 2024-08-14
 

--- a/controllers/eks_config_map_test.go
+++ b/controllers/eks_config_map_test.go
@@ -50,6 +50,8 @@ var _ = Describe("ConfigMapReconcilerEKS", func() {
                 baseDomain: %s.base.domain.io
                 clusterName: %s
                 oidcDomain: oidc.eks.the-region.amazonaws.com/id/eks123clusterID
+                oidcDomains:
+                - oidc.eks.the-region.amazonaws.com/id/eks123clusterID
                 region: the-region
                 awsPartition: aws
             `, accountID, cluster.Name, cluster.Name))))
@@ -148,6 +150,8 @@ var _ = Describe("ConfigMapReconcilerEKS", func() {
                     awsPartition: cn
                     baseDomain: %s.base.domain.io
                     oidcDomain: oidc.eks.some-other-region.amazonaws.com.cn/id/eks123clusterID
+                    oidcDomains:
+                    - oidc.eks.some-other-region.amazonaws.com.cn/id/eks123clusterID
                     clusterName: %s
                     region: some-other-region
                 `, someOtherAccount, cluster.Name, cluster.Name),
@@ -253,6 +257,8 @@ var _ = Describe("ConfigMapReconcilerEKS", func() {
                   vpcId: vpc-1
                 baseDomain: %s.base.domain.io
                 oidcDomain: oidc.eks.cn-north-1.amazonaws.com.cn/id/eks123clusterID
+                oidcDomains:
+                - oidc.eks.cn-north-1.amazonaws.com.cn/id/eks123clusterID
                 clusterName: %s
                 region: cn-north-1
                 awsPartition: aws-cn
@@ -316,6 +322,8 @@ var _ = Describe("ConfigMapReconcilerEKS", func() {
                 awsPartition: aws
                 baseDomain: %s.base.domain.io
                 oidcDomain: oidc.eks.the-region.amazonaws.com/id/eks123clusterID
+                oidcDomains:
+                - oidc.eks.the-region.amazonaws.com/id/eks123clusterID
                 clusterName: %s
                 region: the-region
             `, accountID, cluster.Name, cluster.Name))))


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/31589

See also https://github.com/giantswarm/cluster/pull/323 and https://github.com/giantswarm/cluster-aws/pull/814 which adds the `AWSCluster` annotation.