### PR TITLE
Add the `node` security group id to the ConfigMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dynamically calculate CAPI and CAPA versions from go cache, so that we use the right path when installing the CRDs during tests.
+
+### Added
+
 - Add the `node` security group id to the ConfigMap
 
 ## [0.3.0] - 2024-09-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dynamically calculate CAPI and CAPA versions from go cache, so that we use the right path when installing the CRDs during tests.
+- Add the `node` security group id to the ConfigMap
 
 ## [0.3.0] - 2024-09-20
 

--- a/controllers/capa_config_map_test.go
+++ b/controllers/capa_config_map_test.go
@@ -319,6 +319,9 @@ var _ = Describe("ConfigMapReconcilerCAPA", func() {
 				capa.SecurityGroupControlPlane: {
 					ID: "sg-789987",
 				},
+				capa.SecurityGroupNode: {
+					ID: "sg-898989",
+				},
 			}
 			err = k8sClient.Status().Update(ctx, awsCluster)
 			Expect(err).NotTo(HaveOccurred())

--- a/controllers/capa_config_map_test.go
+++ b/controllers/capa_config_map_test.go
@@ -45,6 +45,7 @@ var _ = Describe("ConfigMapReconcilerCAPA", func() {
 		Expect(configMap.Data).To(HaveKeyWithValue("values", MatchYAML(fmt.Sprintf(`
                 accountID: "%s"
                 awsCluster:
+                  securityGroups: {}
                   vpcId: vpc-1
                 baseDomain: %s.base.domain.io
                 clusterName: %s
@@ -145,6 +146,7 @@ var _ = Describe("ConfigMapReconcilerCAPA", func() {
 				"values": fmt.Sprintf(`
                     accountID: "%s"
                     awsCluster:
+                        securityGroups: {}
                         vpcId: vpc-1
                     awsPartition: cn
                     baseDomain: %s.base.domain.io
@@ -270,6 +272,7 @@ var _ = Describe("ConfigMapReconcilerCAPA", func() {
 			Expect(configMap.Data).To(HaveKeyWithValue("values", MatchYAML(fmt.Sprintf(`
                 accountID: "%s"
                 awsCluster:
+                  securityGroups: {}
                   vpcId: vpc-1
                 baseDomain: %s.base.domain.io
                 oidcDomain: irsa.%s.base.domain.io
@@ -340,8 +343,8 @@ var _ = Describe("ConfigMapReconcilerCAPA", func() {
                   securityGroups:
                     controlPlane:
                       id: sg-789987
-										node:
-											id: sg-898989
+                    node:
+                      id: sg-898989
                   vpcId: vpc-123456
                 awsPartition: aws
                 baseDomain: %s.base.domain.io
@@ -375,6 +378,7 @@ var _ = Describe("ConfigMapReconcilerCAPA", func() {
 			Expect(configMap.Data).To(HaveKeyWithValue("values", MatchYAML(fmt.Sprintf(`
                 accountID: "%s"
                 awsCluster:
+                  securityGroups: {}
                   vpcId: vpc-123456
                 awsPartition: aws
                 baseDomain: %s.base.domain.io

--- a/controllers/capa_config_map_test.go
+++ b/controllers/capa_config_map_test.go
@@ -337,6 +337,8 @@ var _ = Describe("ConfigMapReconcilerCAPA", func() {
                   securityGroups:
                     controlPlane:
                       id: sg-789987
+										node:
+											id: sg-898989
                   vpcId: vpc-123456
                 awsPartition: aws
                 baseDomain: %s.base.domain.io

--- a/controllers/config_map.go
+++ b/controllers/config_map.go
@@ -150,11 +150,16 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		clusterInfo.OIDCDomain = irsaTrustDomains[0]
 		clusterInfo.OIDCDomains = irsaTrustDomains
 
+		clusterInfo.SecurityGroups = &crossplaneConfigValuesAWSClusterSecurityGroups{}
+
 		if sg, ok := awsCluster.Status.Network.SecurityGroups[capa.SecurityGroupControlPlane]; ok {
-			if clusterInfo.SecurityGroups == nil {
-				clusterInfo.SecurityGroups = &crossplaneConfigValuesAWSClusterSecurityGroups{}
-			}
 			clusterInfo.SecurityGroups.ControlPlane = &crossplaneConfigValuesAWSClusterSecurityGroup{
+				ID: sg.ID,
+			}
+		}
+
+		if sg, ok := awsCluster.Status.Network.SecurityGroups[capa.SecurityGroupNode]; ok {
+			clusterInfo.SecurityGroups.Node = &crossplaneConfigValuesAWSClusterSecurityGroup{
 				ID: sg.ID,
 			}
 		}
@@ -289,6 +294,7 @@ type crossplaneConfigValuesAWSCluster struct {
 type crossplaneConfigValuesAWSClusterSecurityGroups struct {
 	// Filled once available
 	ControlPlane *crossplaneConfigValuesAWSClusterSecurityGroup `json:"controlPlane,omitempty"`
+	Node         *crossplaneConfigValuesAWSClusterSecurityGroup `json:"node,omitempty"`
 }
 
 type crossplaneConfigValuesAWSClusterSecurityGroup struct {


### PR DESCRIPTION
This will add the node security group id to the Crossplane ConfigMap, together with the control plane one.